### PR TITLE
[5주차] 강이규

### DIFF
--- a/src/main/java/org/example/week_05/Boj_16929_TwoDots_강이규.java
+++ b/src/main/java/org/example/week_05/Boj_16929_TwoDots_강이규.java
@@ -1,0 +1,64 @@
+package org.example.week_05;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class Boj_16929_TwoDots_강이규 {
+
+    static int n, m;
+    static char[][] map;
+    static boolean[][] visited;
+    static int[][] moves = {{-1, 0}, {1, 0}, {0, -1}, {0, 1}};
+    static char color;
+
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        n = Integer.parseInt(st.nextToken());
+        m = Integer.parseInt(st.nextToken());
+
+        map = new char[n][m];
+        visited = new boolean[n][m];
+
+        for (int i = 0; i < n; i++) {
+            map[i] = br.readLine().toCharArray();
+        }
+
+        for (int i = 0; i < n; i++) {
+            for (int j = 0; j < m; j++) {
+                if (visited[i][j]) continue;
+
+                color = map[i][j];
+                dfs(i, j, i, j);
+            }
+        }
+        System.out.println("No");
+    }
+
+    private static void dfs(int r, int c, int preR, int preC) {
+        visited[r][c] = true;
+
+        for (int[] move : moves) {
+            int nr = r + move[0];
+            int nc = c + move[1];
+
+            if (!isValid(nr, nc)) continue;
+            if (visited[nr][nc]) {
+                if (nr == preR && nc == preC) continue;
+                // visited & not pre
+                System.out.println("Yes");
+                System.exit(0);
+            }
+            dfs(nr, nc, r, c);
+        }
+    }
+
+    private static boolean isValid(int r, int c) {
+        return (0 <= r && r < n) && (0 <= c && c < m) && map[r][c] == color;
+    }
+
+}

--- a/src/main/java/org/example/week_05/Boj_16947_서울지하철2호선_강이규.java
+++ b/src/main/java/org/example/week_05/Boj_16947_서울지하철2호선_강이규.java
@@ -1,0 +1,91 @@
+package org.example.week_05;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.*;
+
+public class Boj_16947_서울지하철2호선_강이규 {
+
+    static int n;
+    static int[] dists;
+    static List<Integer>[] adjList;
+    static boolean[] isCycle;
+    static int start;
+
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+        n = Integer.parseInt(br.readLine());
+        adjList = new ArrayList[n+1];
+        dists = new int[n+1];
+        isCycle = new boolean[n+1];
+
+        for (int i = 1; i <= n; i++) {
+            adjList[i] = new ArrayList<>();
+        }
+
+        for (int i = 0; i < n; i++) {
+            st = new StringTokenizer(br.readLine());
+            int from = Integer.parseInt(st.nextToken());
+            int to = Integer.parseInt(st.nextToken());
+
+            // 무향 그래프
+            adjList[from].add(to);
+            adjList[to].add(from);
+        }
+        // 사이클 찾기
+        for (int i = 1; i <= n; i++) {
+            start = i;
+            if (dfs(i, i)) break;
+            isCycle = new boolean[n+1];
+        }
+        // 거리 구하기
+        for (int i = 1; i <= n; i++) {
+            if (isCycle[i]) continue;
+            dists[i] = bfs(i);
+        }
+
+        StringBuilder sb = new StringBuilder();
+        for (int i = 1; i <= n; i++) {
+            sb.append(dists[i]).append(" ");
+        }
+        System.out.println(sb);
+    }
+
+    private static int bfs(int start) {
+        // 사이클로부터의 거리 반환
+        boolean[] visited = new boolean[n+1];
+        Queue<int[]> q = new ArrayDeque<>(); // 노드, 거리
+        q.offer(new int[]{start, 0});
+        visited[start] = true;
+
+        while (!q.isEmpty()) {
+            int[] info = q.poll();
+            int cur = info[0];
+
+            int nextDist = info[1] + 1;
+            for (int adj : adjList[cur]) {
+                if (visited[adj]) continue;
+                if (isCycle[adj]) return nextDist;
+                q.offer(new int[]{adj, nextDist});
+                visited[adj] = true;
+            }
+        }
+        return -1;
+    }
+
+    private static boolean dfs(int cur, int pre) {
+        // 사이클 찾기
+        isCycle[cur] = true;
+
+        for (int next : adjList[cur]) {
+            if (isCycle[next]) {
+                if (next == start && next != pre) return true;
+            } else if (dfs(next, cur)) return true;
+        }
+        isCycle[cur] = false;
+        return false;
+    }
+}


### PR DESCRIPTION
## Q1. Two Dots (Success)
**1. 난이도** : Gold 4
**2. 풀이 핵심** : DFS

**3.시간/공간 복잡도** :  O(NM) / O(NM)
- 인접리스트 DFS의 시간복잡도 = O(V*E)라고 한다.(방문 정점 수 V + next 고를 때 체크한 간선 수 E)
- 여기선 사방을 탐색하므로, 간선 수 = 정점 수 * 4. --> 시간복잡도 = O(NM + 4NM) = O(5NM)

**4. 풀이 설명** 
- Color 값이 같을 때만 방문하는 DFS
- 인접 노드 중 이미 방문한 곳을 찾았을 때, 최소 3번 전에 방문한 노드(=전전전 노드)여야 사이클이다.
  - 대각선을 인접노드로 보지 않는 구조상, 전전 노드는 만날 수 없으므로
    전 노드인 경우만 제외해주면 사이클 판별이 가능하다.


---
## Q2. 서울 지하철 2호선 (Failed)
**1. 난이도** : Gold 3
**2. 풀이 핵심** : DFS, BFS
**3.시간/공간 복잡도** : O(N^2),,? / O(N)
- 시간복잡도 : 
  - bfs의 경우, 최소 크기의 사이클에 나머지 노드들이 한줄로 연결되어 있는 때가 최악의 경우 -> O(N^2)
  - dfs의 경우는 정확히 모르겠다.

**4. 풀이 설명** 
- DFS를 통해 사이클(=순환선)을 찾는다.
- 이 때 DFS 시작 노드가 아닌 중간 노드와 만나는 경우도 사이클로 판별하면,
  한 번 시작한 DFS 안에서 '사이클이 아닌 것' (= 시작 노드 ~ 중간 노드 부분)을 분리하기 어렵다.
- 따라서 **시작 노드와 만나는 경우만** 사이클로 판별한다.
- 사이클(순환선)을 찾고 나면, 사이클에 속하지 않는 모든 노드에 대해 BFS를 실행해 사이클까지의 거리를 구한다.

**5. 어려웠던 점**
- Two Dots처럼 그저 '사이클이 있는지를 판단하는 것' 까지는 알았는데,
  DFS중 중간 노드와 만났을 때도 사이클로 판별하는 식으로 구현했고,
  시작 노드~ 중간 노드까지를(사이클에 포함 안 되는 부분을) 구분해줄 방법을 떠올리지 못했다.


- DFS 시작 전 매번 isCycle을 초기화해주는 지금과 같은 방법은 다른 블로그의 풀이를 참고했다.
