### PR TITLE
[6주차] 김희연

### DIFF
--- a/src/main/java/org/example/week_06/Boj_1647_도시분할계획_김희연.java
+++ b/src/main/java/org/example/week_06/Boj_1647_도시분할계획_김희연.java
@@ -1,0 +1,89 @@
+package org.example.week_06;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.StringTokenizer;
+
+public class Boj_1647_도시분할계획_김희연 {
+
+	static class Edge implements Comparable<Edge>{
+		int start;
+		int end;
+		int weight;
+
+		Edge(int start, int end, int weight){
+			this.start = start;
+			this.end = end;
+			this.weight = weight;
+		}
+
+		@Override
+		public int compareTo(Edge o) {
+			return Integer.compare(this.weight, o.weight);
+		}
+	}
+
+	static int N, M;
+	static int[] parents;
+	static ArrayList<Edge> edgeList;
+
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st;
+		st = new StringTokenizer(br.readLine());
+		N = Integer.parseInt(st.nextToken());
+		M = Integer.parseInt(st.nextToken());
+
+		edgeList = new ArrayList<>();
+		for(int i=0; i<M; i++) {
+			st = new StringTokenizer(br.readLine());
+			int start = Integer.parseInt(st.nextToken());
+			int end = Integer.parseInt(st.nextToken());
+			int weight = Integer.parseInt(st.nextToken());
+
+			edgeList.add(new Edge(start, end, weight));
+		}
+
+		make();
+
+		Collections.sort(edgeList);
+
+		int ans = 0;
+		int cost = 0;
+		for(int i=0; i<edgeList.size(); i++) {
+			Edge edge = edgeList.get(i);
+
+			if(union(edge.start, edge.end)) {
+				ans += edge.weight;
+
+				cost = edge.weight;
+			}
+		}
+
+		System.out.println(ans - cost);
+	}
+
+	public static void make() {
+		parents = new int[N+1];
+		for(int i=1; i<=N; i++) {
+			parents[i] = i;
+		}
+	}
+
+	public static int find(int a) {
+		if(parents[a] == a) return a;
+		return parents[a] = find(parents[a]);
+	}
+
+	public static boolean union(int a, int b) {
+		int aRoot = find(a);
+		int bRoot = find(b);
+		if(aRoot == bRoot) return false;
+
+		parents[bRoot] = aRoot;
+		return true;
+	}
+}

--- a/src/main/java/org/example/week_06/Boj_3665_최종순위_김희연.java
+++ b/src/main/java/org/example/week_06/Boj_3665_최종순위_김희연.java
@@ -1,0 +1,101 @@
+package org.example.week_06;
+
+import java.io.*;
+import java.util.*;
+
+public class Boj_3665_최종순위_김희연 {
+	static int N, M;
+	static ArrayList<Integer>[] adjList;
+	static int[] inDegree;
+
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		int T = Integer.parseInt(br.readLine());
+
+		for (int tc = 0; tc < T; tc++) {
+			N = Integer.parseInt(br.readLine());
+			int[] lastYear = new int[N];
+			StringTokenizer st = new StringTokenizer(br.readLine(), " ");
+			for (int i = 0; i < N; i++) {
+				lastYear[i] = Integer.parseInt(st.nextToken());
+			}
+
+			// 그래프 초기화
+			adjList = new ArrayList[N + 1];
+			for (int i = 1; i <= N; i++) {
+				adjList[i] = new ArrayList<>();
+			}
+			inDegree = new int[N + 1];
+
+			// 작년 순위를 바탕으로 그래프 생성
+			for (int i = 0; i < N; i++) {
+				for (int j = i + 1; j < N; j++) {
+					adjList[lastYear[i]].add(lastYear[j]);
+					inDegree[lastYear[j]]++;
+				}
+			}
+
+			// 순위 변경 정보에 따라 그래프 갱신
+			M = Integer.parseInt(br.readLine());
+			for (int i = 0; i < M; i++) {
+				st = new StringTokenizer(br.readLine(), " ");
+				int a = Integer.parseInt(st.nextToken());
+				int b = Integer.parseInt(st.nextToken());
+				// a가 b보다 앞에 있다면 순서 변경
+				if (adjList[a].contains(b)) {
+					adjList[a].remove((Integer) b);
+					adjList[b].add(a);
+					inDegree[b]--;
+					inDegree[a]++;
+				} else {
+					adjList[b].remove((Integer) a);
+					adjList[a].add(b);
+					inDegree[a]--;
+					inDegree[b]++;
+				}
+			}
+
+
+			ArrayList<Integer> result = topologySort();
+
+
+			if (result.size() == N) {
+				for (int i : result) {
+					System.out.print(i + " ");
+				}
+				System.out.println();
+			} else if (result.size() > N) {
+				System.out.println("?");
+			} else {
+				System.out.println("IMPOSSIBLE");
+			}
+		}
+	}
+
+	private static ArrayList<Integer> topologySort() {
+		ArrayList<Integer> orderList = new ArrayList<>();
+		Queue<Integer> queue = new LinkedList<Integer>();
+
+		for (int i = 1; i <= N; i++) {
+			if (inDegree[i] == 0)
+				queue.offer(i);
+		}
+
+		while (!queue.isEmpty()) {
+			if (queue.size() > 1) { // 불확실한 순위
+				orderList.add(N + 1); // 임의의 값을 추가하여 크기 증가
+				break;
+			}
+
+			int cur = queue.poll();
+			orderList.add(cur);
+
+			for (int next : adjList[cur]) {
+				if (--inDegree[next] == 0)
+					queue.offer(next);
+			}
+		}
+
+		return orderList;
+	}
+}


### PR DESCRIPTION
## Q1. 도시 분할 계획 (Success)

**1. 난이도** : Gold 4

**2. 풀이 핵심** : 크루스칼

**3.시간/공간 복잡도** :  O(MlogM) / O(M)
- 시간 복잡도 : O(ElogE)
- 공간 복잡도O(N + E) (N은 정점의 개수, E는 간선의 개수)

**4. 풀이 설명**
- 간선 리스트 생성: 모든 간선의 정보를 `edgeList`에 저장
- 유니온-파인드 초기화: make()함수를 통해 각 정점의 부모 노드를 자기 자신으로 초기화
- 간선 정렬: 간선 리스트를 가중치에 따라 오름차순 정렬(비용이 작은 값이 우선)
- 간선 연결: union()함수를 통해 정렬된 간선 리스트를 순회하면서 두 정점이 아직 연결되지 않았다면 연결하고, 가중치를 결과에 더함
- **최종 결과**: 가중치 합(ans)에서 가장 큰 가중치(cost)를 뺌

**5. 어려웠던 점**

- 유지비의 합을 최소로 하기 위해서, 가장 큰 가중치를 제거하면 된다는 아이디어만 있으면 쉽게 풀 수 있는 문제였던 것 같다.

---

## Q2. 최종 순위 (Success)
**1. 난이도** : Gold 1

**2. 풀이 핵심** : 위상 정렬

**3.시간/공간 복잡도**
- 시간 복잡도: 잘 모르겠음..
- 공간 복잡도: 그래프와 진입차수 배열을 저장하기 위한 공간이 필요하므로 O(N)

**4. 풀이 설명**
- 작년의 순위를 입력받아 순서대로 그래프의 방향을 설정
    - 예를 들어, 작년 순위가 "1 2 3"이라면 1 -> 2, 1 -> 3, 2 -> 3의 방향을 가진 그래프를 초기화
- 각 노드에 대한 진입 차수도 초기화
- 순위가 변경된 쌍의 정보를 입력받아 그래프의 방향을 바꾸고 진입차수를 업데이트
    - 2와 3의 순위가 변경되었다면 2 -> 3의 방향을 3 -> 2로 변경하고, 각 노드의 진입 차수를 조정
- **위상 정렬**
    - 진입차수가 0인 노드부터 큐에 넣음
    - 큐에서 노드를 하나씩 빼면서 해당 노드에서 나가는 간선을 제거하고 진입차수를 업데이트
        - 만약 진입차수가 0인 노드가 한 번에 둘 이상 발견되면 확실한 순위를 결정할 수 없음
        - 모든 노드를 방문하기 전에 큐가 빈다면, 순환 구조가 존재하므로 순위를 정할 수 없음
- 위상 정렬의 결과를 바탕으로 확실한 순위를 결정할 수 있는지, 불가능한지, 순환 구조가 존재하는지를 판단하여 결과를 출력

**5. 어려웠던 점**
- 알고리즘이 잘 생각이 나지 않아서 블로그에서 힌트를 얻었고, 위상 정렬에 대한 부분은 수업 시간에 배운 내용을 응용하였다.
- 순위 변경 정보를 바탕으로 그래프를 업데이트할 때, 두 팀의 원래 순위를 확인하고 해당 정보를 바탕으로 업데이트해야 하는 부분이 어려웠다.