### PR TITLE
[7주차] 강이규

### DIFF
--- a/src/main/java/org/example/week_07/Boj_10800_컬러볼_강이규.java
+++ b/src/main/java/org/example/week_07/Boj_10800_컬러볼_강이규.java
@@ -1,0 +1,67 @@
+package org.example.week_07;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.*;
+
+public class Boj_10800_컬러볼_강이규 {
+
+    static int N;
+    static int[][] arr;
+    static int[] sums;
+
+    static int[] result;
+    static int totalSum;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        N = Integer.parseInt(br.readLine());
+
+        sums = new int[N+1];
+        totalSum = 0;
+        arr = new int[N+1][3]; // color, size, idx
+        result = new int[N+1];
+
+        for (int i = 1, end = N+1; i < end; i++) {
+            StringTokenizer st = new StringTokenizer(br.readLine());
+
+            int color = Integer.parseInt(st.nextToken());
+            int size = Integer.parseInt(st.nextToken());
+
+            arr[i][0] = color;
+            arr[i][1] = size;
+            arr[i][2] = i;
+        }
+        // sort
+        Arrays.sort(arr, Comparator.comparingInt(a -> a[1]));
+
+        // max O(2N)
+        Map<Integer, Integer> sameSizeCnt = new HashMap<>(); // color, cnt
+        for (int i = 1, end = N+1; i < end; i++) {
+            int color = arr[i][0];
+            int size = arr[i][1];
+            int prevSize = arr[i-1][1];
+
+            if (size != prevSize) {
+                sameSizeCnt.forEach((k, v) -> {
+                    int val = v * prevSize;
+                    sums[k] += val;
+                    totalSum += val;
+                });
+                sameSizeCnt = new HashMap<>();
+            }
+            Integer val = sameSizeCnt.get(color);
+            sameSizeCnt.put(color, (val != null) ? val+1 : 1);
+            result[arr[i][2]] = totalSum - sums[color];
+        }
+
+        StringBuilder sb = new StringBuilder();
+        for (int i = 1, end = N+1; i < end; i++) {
+            sb.append(result[i]).append("\n");
+        }
+
+        System.out.println(sb);
+    }
+}

--- a/src/main/java/org/example/week_07/Boj_2098_외판원순회_강이규.java
+++ b/src/main/java/org/example/week_07/Boj_2098_외판원순회_강이규.java
@@ -1,0 +1,54 @@
+package BOJ;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.StringTokenizer;
+
+public class Q_2098 {
+
+    static int N;
+    static int[][] adjMatrix;
+    static int[][] dp;
+    static final int INF = 16_000_000; // 최대값
+    static int maxFlag; // 모두 방문했을 때
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        N = Integer.parseInt(br.readLine());
+        dp = new int[N][1<<(N+1)];
+        maxFlag = (1<<N) - 1;
+
+        adjMatrix = new int[N][N];
+        for (int i = 0; i < N; i++) {
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            for (int j = 0; j < N; j++) {
+                adjMatrix[i][j] = Integer.parseInt(st.nextToken());
+            }
+            Arrays.fill(dp[i], -1);
+        }
+
+        System.out.println(dfs(0, 1));
+    }
+
+    private static int dfs(int cur, int flag) {
+        // 모두 방문
+        if (flag == maxFlag) {
+            int tmpCost = adjMatrix[cur][0];
+            return tmpCost != 0 ? tmpCost : INF;
+        }
+        // 방문했던 노드일 때
+        if (dp[cur][flag] != -1) return dp[cur][flag];
+        dp[cur][flag] = INF;
+
+        // next
+        for (int i = 0; i < N; i++) {
+            if ((flag & 1<<i) != 0 || adjMatrix[cur][i] == 0) continue;
+            // 방문하지 않았고, 갈 수 있으면
+            dp[cur][flag] = Math.min(dp[cur][flag], dfs(i, flag | 1<<i) + adjMatrix[cur][i]);
+        }
+        return dp[cur][flag];
+    }
+}

--- a/src/main/java/org/example/week_07/Boj_2098_외판원순회_강이규.java
+++ b/src/main/java/org/example/week_07/Boj_2098_외판원순회_강이규.java
@@ -1,4 +1,4 @@
-package BOJ;
+package org.example.week_07;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -6,7 +6,7 @@ import java.io.InputStreamReader;
 import java.util.Arrays;
 import java.util.StringTokenizer;
 
-public class Q_2098 {
+public class Boj_2098_외판원순회_강이규 {
 
     static int N;
     static int[][] adjMatrix;


### PR DESCRIPTION
## Q1. 컬러볼 (Success)
**1. 난이도** : Gold 2
**2. 풀이 핵심** : 정렬, 누적합

**3.시간/공간 복잡도** :  O(NlogN) / O(N)

**4. 풀이 설명** 
- result[n] = (n번째 공보다 크기가 작은) (모든 공들의 크기의 합 - 같은 색 공들의 크기 합) 이다.
  - 이를 구현하기 위해, 먼저 공들을 크기 오름차순으로 정렬한다.
  - int totalSum과 int[] sums를 둔다. sums에는 각 색상별 공 크기의 합을 저장한다.
  - 정렬된 배열을 순회하면서 totalSum과 sums[color]를 업데이트한다. 단 크기가 같은 공이 있는 경우를 처리하기 위해, Map에 임시 저장한 후, 크기가 n-1번째 공보다 커지는 경우에 Map을 flush하면서 내용을 totalSum과 sums에 업데이트한다.
    - Map의 키는 color, 값은 같은 크기 공의 개수이다.

**5. 어려웠던 점**
- 같은 색의 공을 제외하는 것은 쉬웠지만, 같은 크기의 공을 제외해주는 것을 구현하기 어려웠다.

---
## Q2. 외판원 순회 (Failed)
**1. 난이도** : Gold 1
**2. 풀이 핵심** : DP, DFS
**3.시간/공간 복잡도** : O(N^2 * 2^N) / O(N * 2^N)
- 시간복잡도: dp 테이블의 값은 2^N(=부분집합 개수) * N개가 있고, 각각을 처음 탐색할 때 N번만큼 루프를 돈다.

**4. 풀이 설명** 
- 2차원 dp테이블을 사용한다.(dp[node][flag] = node로부터, 아직 방문하지 않은 노드들을 거쳐 출발점에 도착하는 최소 비용)
  - flag는 그 시점까지 방문한 노드들을 비트마스킹한 값이다.
  - flag를 가지고 node에 방문한 상황에서, dp[node][flag] 값이 있다면(이미 방문했었다면) 그 값을 리턴한다.
  - 없다면, 그 뒤로 가능한 모든 상황들을 DFS한 후, 최소값을 dp[node][flag]에 저장한다.
  - 모두 끝난 후, dp[start][1]을 출력한다. start는 어느 노드든 상관없다.

**5. 어려웠던 점**
- DP를 어떻게 적용해야 할지 몰라서, 처음엔 거의 사용하지 못한, 일반 DFS와 같은 풀이를 시도했다.
- 시간초과가 났고, 풀이가 떠오르지 않아 다른 사람의 풀이를 참고했다.